### PR TITLE
Fix Wpedantic warnings and linker errors

### DIFF
--- a/debug.hpp
+++ b/debug.hpp
@@ -42,7 +42,7 @@ namespace debug_tm{
         constexpr bool verbose_mode = false;
     #endif
 
-    out_tm::output_type& dout()
+    inline out_tm::output_type& dout()
     {
         static out_tm::output_type static_dout;
         return static_dout;

--- a/mark_pointer.hpp
+++ b/mark_pointer.hpp
@@ -106,5 +106,5 @@ namespace mark {
         return bool(size_t(ptr) & (~lower<15>()));
     }
 
-}; // namespace mark
-}; // namespace utils_tm
+} // namespace mark
+} // namespace utils_tm

--- a/memory_reclamation/counting_reclamation.hpp
+++ b/memory_reclamation/counting_reclamation.hpp
@@ -313,5 +313,5 @@ namespace reclamation_tm
         }
 
     }
-};
-};
+}
+}

--- a/memory_reclamation/default_destructor.hpp
+++ b/memory_reclamation/default_destructor.hpp
@@ -13,5 +13,5 @@ namespace reclamation_tm {
             h.delete_raw(ptr);
         }
     };
-};
-};
+}
+}

--- a/memory_reclamation/reclamation_guard.hpp
+++ b/memory_reclamation/reclamation_guard.hpp
@@ -92,5 +92,5 @@ reclamation_guard<T,R>::~reclamation_guard()
         return reclamation_guard<T,ReclamationType>(rec, aptr);
     }
 
-};
-};
+}
+}

--- a/output.hpp
+++ b/output.hpp
@@ -113,7 +113,7 @@ inline output_type& operator<<(output_type& cons, manipulator_type t)
 
 
 // THE STATIC OUTPUT OBJECT (THIS REPLACES std::cout) **************************
-output_type& out()
+inline output_type& out()
 {
     static output_type static_out;
     return static_out;
@@ -167,7 +167,7 @@ inline locally_buffered_output<O>& operator<<(locally_buffered_output<O>& lbo,
 }
 
 
-locally_buffered_output<output_type>& buffered_out()
+inline locally_buffered_output<output_type>& buffered_out()
 {
     static thread_local locally_buffered_output<output_type> local_out(out());
     return local_out;


### PR DESCRIPTION
Remove extra ';' to silence -Wpedantic warnings. 